### PR TITLE
fix: 🐞 Corrigindo replace do AtomsIconSVG

### DIFF
--- a/components/atoms/IconSVG/index.vue
+++ b/components/atoms/IconSVG/index.vue
@@ -58,19 +58,22 @@ watchEffect(getIcon);
 watchSyncEffect(() => {
   if (props.filled) {
     icon.value = icon.value.replace(
-      /fill=".*?"/g,
-      `fill="${props.currentColor}"`,
+      / fill=".*?"/g,
+      ` fill="${props.currentColor}"`,
     );
   }
 
   if (props.width) {
-    icon.value = icon.value.replace(/width=".*?"/g, `width="${props.width}"`);
+    icon.value = icon.value.replace(
+      / width=".*?"/g,
+      ` width="${props.width}"`
+    );
   }
 
   if (props.height) {
     icon.value = icon.value.replace(
-      /height=".*?"/g,
-      `height="${props.height}"`,
+      / height=".*?"/g,
+      ` height="${props.height}"`,
     );
   }
 });


### PR DESCRIPTION
## Problema:
`icon.value.replace()` estava procurando dentro do ícone se havia `width=".*?"` dentro do ícone, se tiver, substitui o valor encontrado por `width="${props.width}"`. O problema é quando o ícone tiver `stroke-width="?"` essa variável também dará match com o RegEx, possivelmente quebrando a SVG.

## Solução proposta:
Adicionar um espaço antes do width no RegEx: ` width=".*?"` 
Assim garante que o que será encontrado será de fato a variável que desejamos trocar e com isso stroke-width não dará match por conter um hífen antes do width.

## Exemplo:
### ANTES:
![Captura de tela de 2024-08-13 11-14-57](https://github.com/user-attachments/assets/74bf84aa-4ba9-41f1-97f4-1934a0e1e5a6)
![Captura de tela de 2024-08-13 11-15-47](https://github.com/user-attachments/assets/e6f93783-9268-4636-9e68-560579783a2c)

### DEPOIS:
![Captura de tela de 2024-08-13 11-13-29](https://github.com/user-attachments/assets/f503bffd-fd17-4d90-810b-0c7cddd1f29f)
![Captura de tela de 2024-08-13 11-16-45](https://github.com/user-attachments/assets/ffa168e6-64a6-4bb4-a9f3-66ebb600f3a2)

## Finalizando:
O código proposto altera o erro de uma forma bem simples, mas funcional. Também foi feito essa correção nos outros replaces para garantir que esse tipo de caso não irá acontecer novamente, e o código do replace width também foi formatado semelhante aos outros replace.